### PR TITLE
Custom Translation Feature - Footer ID Update

### DIFF
--- a/assets/js/layout/footer.js
+++ b/assets/js/layout/footer.js
@@ -8,7 +8,7 @@ $(() => {
 })
 
 function initLocaleSelection () {
-  const select = new MDCSelect(document.querySelector('.mdc-select--locale'))
+  const select = new MDCSelect(document.querySelector('#footer-language-selector'))
 
   select.listen('MDCSelect:change', () => {
     document.cookie = `hl= ${select.value}; path=/`

--- a/templates/Default/footer.html.twig
+++ b/templates/Default/footer.html.twig
@@ -79,7 +79,7 @@
         </div>
 
         <div class="form-group col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2 mt-3 mt-sm-0">
-          <div class="mdc-select mdc-select--outlined mdc-select--locale">
+          <div id="footer-language-selector" class="mdc-select mdc-select--outlined mdc-select--locale">
             <div class="mdc-select__anchor" aria-labelledby="outlined-select-label">
               <span class="mdc-notched-outline">
                 <span class="mdc-notched-outline__leading"></span>


### PR DESCRIPTION
Add and ID to the language selector in the footer and use the ID instead
of the class to select the language selector so there can be new selectors
added in the custom translation feature

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [ ] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no warnings and errors 
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [ ] Perform a self-review of the changes
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [ ] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
- [ ] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description
In upcoming PRs for the custom translation feature, there will be new selectors added which would overlap with the language selector without this change.

### Tests - additional information
No additional tests for this update
