### PR TITLE
Fix iTranslate api error

### DIFF
--- a/assets/js/custom/Translation.js
+++ b/assets/js/custom/Translation.js
@@ -16,24 +16,8 @@ export class Translation {
   }
 
   setTargetLanguage () {
-    let decodedCookie
-    try {
-      decodedCookie = document.cookie
-        .split(';')
-        .map(v => v.split('='))
-        .reduce((acc, v) => {
-          acc[decodeURIComponent(v[0].trim())] = decodeURIComponent(v[1].trim())
-          return acc
-        }, {})
-    } catch (e) {
-      console.error("Can't decode cookie")
-    }
-
-    if (decodedCookie !== undefined && decodedCookie.hl !== undefined) {
-      this.targetLanguage = decodedCookie.hl.replace('_', '-')
-    } else {
-      this.targetLanguage = document.documentElement.lang
-    }
+    const appLanguage = $('#app-language').data('app-language')
+    this.targetLanguage = appLanguage.replace('_', '-')
   }
 
   setDisplayLanguageMap () {

--- a/templates/Default/base.html.twig
+++ b/templates/Default/base.html.twig
@@ -44,6 +44,7 @@
 {% include 'Default/footer.html.twig' %}
 
 <div id="app-version" data-app-version="{{ app_version }}" style="display: none;">{{ app_version }}</div>
+<div id="app-language" data-app-language="{{ app.request.locale }}"></div>
 <div class="js-app-env" data-app-env="'{{ app_env }}"></div>
 <div class="js-user-state" data-is-user-logged-in="{{ app.user != null }}"></div>
 <div id="js-api-routing"


### PR DESCRIPTION
Short language code like pt, zh is sent when iTranslate requires long ones like pt-PT and zh-CN

This happens when the hl language cookie is not set. This commit moves away from reliance on cookies.

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [ ] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no warnings and errors 
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [ ] Perform a self-review of the changes
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [ ] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
- [ ] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description
`TODO: Add additional information that is not in your commit-message here`

### Tests - additional information
No tests since pt is technically not a wrong language code, in fact google translate would accept that. It's only an integration problem with itranslate