### PR TITLE
Program Editor Screen

### DIFF
--- a/assets/styles/custom/program.scss
+++ b/assets/styles/custom/program.scss
@@ -613,6 +613,20 @@ input[type="number"] {
   }
 }
 
+.full-screen {
+  position: fixed;
+  top: 50px;
+  left: 0;
+  z-index: 100;
+  width: 100vw;
+  height: calc(100vh - 50px);
+  padding-top: 1rem;
+  padding-right: math.div($grid-gutter-width, 2);
+  padding-left: math.div($grid-gutter-width, 2);
+  overflow-y: auto;
+  background: #fff;
+}
+
 @media only screen and (min-width: 768px) {
   .sign-app-form {
     label {

--- a/assets/styles/layout/sidebar.scss
+++ b/assets/styles/layout/sidebar.scss
@@ -92,6 +92,11 @@ $sidebar-width: 250px;
       left: $sidebar-width;
       width: calc(100vw - #{$sidebar-width});
     }
+
+    .full-screen {
+      left: $sidebar-width;
+      width: calc(100vw - #{$sidebar-width});
+    }
   }
 }
 

--- a/templates/Program/program_description.html.twig
+++ b/templates/Program/program_description.html.twig
@@ -52,16 +52,7 @@
 <div class="row">
   <div class="col">
     {% if app.user and my_program %}
-      <div id="edit-text-ui" class="d-none mb-5">
-        <div class="mt-3">
-          <span class="h2" id="edit-headline"></span>
-            <span>
-              <i data-bs-toggle="tooltip"
-                 id="edit-close-button" class="ml-3 material-icons catro-icon-button align-bottom">
-                close
-              </i>
-            </span>
-        </div>
+      <div id="edit-text-ui" class="d-none mb-5 full-screen">
         <div id="edit-text-instruction"></div>
         <div id="edit-text-error" style="display:none;" class="alert alert-danger"></div>
         <label id="edit-mdc-text-field"

--- a/tests/BehatFeatures/web/project-details/project_credits.feature
+++ b/tests/BehatFeatures/web/project-details/project_credits.feature
@@ -53,7 +53,7 @@ Feature: As a project owner, I should be able to give credits for my project.
     When I click "#edit-credits-button"
     And I wait for AJAX to finish
     Then I fill in "edit-text" with "These are new notes and credits"
-    And I click "#edit-close-button"
+    And I click "#top-app-bar__back__btn-back"
     And I should see "Do you want to save your changes?"
     When I click ".swal2-confirm"
     And I wait for AJAX to finish
@@ -69,7 +69,7 @@ Feature: As a project owner, I should be able to give credits for my project.
     When I click "#edit-credits-button"
     And I wait for AJAX to finish
     Then I fill in "edit-text" with "These are new notes and credits"
-    And I click "#edit-close-button"
+    And I click "#top-app-bar__back__btn-back"
     And I should see "Do you want to save your changes?"
     When I click ".swal2-deny"
     Then the element "#credits" should be visible
@@ -84,7 +84,7 @@ Feature: As a project owner, I should be able to give credits for my project.
     When I click "#edit-credits-button"
     And I wait for AJAX to finish
     Then I fill in "edit-text" with "These are new notes and credits"
-    And I click "#edit-close-button"
+    And I click "#top-app-bar__back__btn-back"
     And I should see "Do you want to save your changes?"
     When I click ".swal2-close"
     And I wait for AJAX to finish

--- a/tests/BehatFeatures/web/project-details/project_description.feature
+++ b/tests/BehatFeatures/web/project-details/project_description.feature
@@ -49,7 +49,7 @@ Feature: Projects should have descriptions that can be changed by the project ow
     When I click "#edit-description-button"
     And I wait for AJAX to finish
     Then I fill in "edit-text" with "This is a new description"
-    And I click "#edit-close-button"
+    And I click "#top-app-bar__back__btn-back"
     And I should see "Do you want to save your changes?"
     When I click ".swal2-confirm"
     And I wait for AJAX to finish
@@ -65,7 +65,7 @@ Feature: Projects should have descriptions that can be changed by the project ow
     When I click "#edit-description-button"
     And I wait for AJAX to finish
     Then I fill in "edit-text" with "This is a new description"
-    And I click "#edit-close-button"
+    And I click "#top-app-bar__back__btn-back"
     And I should see "Do you want to save your changes?"
     When I click ".swal2-deny"
     Then the element "#description" should be visible
@@ -80,7 +80,7 @@ Feature: Projects should have descriptions that can be changed by the project ow
     When I click "#edit-description-button"
     And I wait for AJAX to finish
     Then I fill in "edit-text" with "This is a new description"
-    And I click "#edit-close-button"
+    And I click "#top-app-bar__back__btn-back"
     And I should see "Do you want to save your changes?"
     When I click ".swal2-close"
     And I wait for AJAX to finish

--- a/tests/BehatFeatures/web/project-details/project_name.feature
+++ b/tests/BehatFeatures/web/project-details/project_name.feature
@@ -48,7 +48,7 @@ Feature: Projects should have a name that can be changed by the project owner
     When I click "#edit-name-button"
     And I wait for AJAX to finish
     Then I fill in "edit-text" with "This is a new name"
-    And I click "#edit-close-button"
+    And I click "#top-app-bar__back__btn-back"
     And I should see "Do you want to save your changes?"
     When I click ".swal2-confirm"
     And I wait for AJAX to finish
@@ -64,7 +64,7 @@ Feature: Projects should have a name that can be changed by the project owner
     When I click "#edit-name-button"
     And I wait for AJAX to finish
     Then I fill in "edit-text" with "This is a new name"
-    And I click "#edit-close-button"
+    And I click "#top-app-bar__back__btn-back"
     And I should see "Do you want to save your changes?"
     When I click ".swal2-deny"
     Then the element "#name" should be visible
@@ -79,7 +79,7 @@ Feature: Projects should have a name that can be changed by the project owner
     When I click "#edit-name-button"
     And I wait for AJAX to finish
     Then I fill in "edit-text" with "This is a new name"
-    And I click "#edit-close-button"
+    And I click "#top-app-bar__back__btn-back"
     And I should see "Do you want to save your changes?"
     When I click ".swal2-close"
     Then the element "#edit-text" should be visible


### PR DESCRIPTION
Add a new screen to show the program name, description, and credits editor.
---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [ ] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no warnings and errors 
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [ ] Perform a self-review of the changes
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [ ] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
- [ ] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description
Currently, the program editor is shown on the program page. However, this PR would move the editor to its own screen. In future PRs we will show text fields for the name, description, and credits sections at the same time on this new screen. This will make it easier for users to add and manage custom translations instead of adding translations for each section separately.

### Tests - additional information
There are not any new tests for this PR, but some minor updates to existing tests were made to reflect the changes.
