### PR TITLE
Fixed: Order translation apis based on each request

### DIFF
--- a/src/Translation/GoogleTranslateApi.php
+++ b/src/Translation/GoogleTranslateApi.php
@@ -180,10 +180,10 @@ class GoogleTranslateApi implements TranslationApiInterface
       return 0;
     }
 
-    if (strlen($text) > $this->short_text_length) {
-      return 0;
+    if (strlen($text) <= $this->short_text_length) {
+      return 1;
     }
 
-    return 1;
+    return 0.5;
   }
 }

--- a/src/Translation/ItranslateApi.php
+++ b/src/Translation/ItranslateApi.php
@@ -149,6 +149,6 @@ class ItranslateApi implements TranslationApiInterface
       return 0;
     }
 
-    return 1;
+    return 0.5;
   }
 }

--- a/tests/PhpUnit/Translation/GoogleTranslateApiTest.php
+++ b/tests/PhpUnit/Translation/GoogleTranslateApiTest.php
@@ -79,7 +79,7 @@ class GoogleTranslateApiTest extends TestCase
 
   public function testLongText(): void
   {
-    $this->assertEquals(0, $this->api->getPreference('testing', null, 'en'));
+    $this->assertEquals(0.5, $this->api->getPreference('testing', null, 'en'));
   }
 
   public function testShortText(): void

--- a/tests/PhpUnit/Translation/ItranslateApiTest.php
+++ b/tests/PhpUnit/Translation/ItranslateApiTest.php
@@ -135,8 +135,8 @@ class ItranslateApiTest extends TestCase
 
   public function testSupportedLanguage(): void
   {
-    $this->assertEquals(1, $this->api->getPreference('testing', null, 'en'));
-    $this->assertEquals(1, $this->api->getPreference('testing', 'de', 'en'));
+    $this->assertEquals(0.5, $this->api->getPreference('testing', null, 'en'));
+    $this->assertEquals(0.5, $this->api->getPreference('testing', 'de', 'en'));
   }
 
   private function mockGenericResponse(): ResponseInterface


### PR DESCRIPTION
make the default preference value 0.5 so google translate can handle short request with priority

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [ ] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no warnings and errors 
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [ ] Perform a self-review of the changes
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [ ] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
- [ ] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description
`TODO: Add additional information that is not in your commit-message here`

### Tests - additional information
`TODO: add additional information about testruns here`
